### PR TITLE
use ‘which’ to find the pdftotext binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,8 +78,8 @@ Or easier:
 echo Pdf::getText('book.pdf');
 ```
 
-By default the package will assume that the `pdftotext` command is located at `/usr/bin/pdftotext`.
-If it is located elsewhere pass its binary path to constructor
+By default the package will use `which pdftotext` to determine the path to the `pdftotext` binary.
+You can manually override it by passing the binary path to the constructor.
 
 ```php
 $text = (new Pdf('/custom/path/to/pdftotext'))

--- a/src/Exceptions/BinaryNotFound.php
+++ b/src/Exceptions/BinaryNotFound.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\PdfToText\Exceptions;
+
+use Exception;
+
+class BinaryNotFound extends Exception
+{
+}

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\PdfToText;
 
+use Spatie\PdfToText\Exceptions\BinaryNotFound;
 use Spatie\PdfToText\Exceptions\CouldNotExtractText;
 use Spatie\PdfToText\Exceptions\PdfNotFound;
 use Symfony\Component\Process\Process;
@@ -16,7 +17,18 @@ class Pdf
 
     public function __construct(string $binPath = null)
     {
-        $this->binPath = $binPath ?? '/usr/bin/pdftotext';
+        $this->binPath = $binPath ?? $this->generateBinPath();
+    }
+
+    protected function generateBinPath()
+    {
+        $path = exec('which pdftotext');
+
+        if (empty($path)) {
+            throw new BinaryNotFound("Could not find the `pdftotext` binary on your system.");
+        }
+
+        return $path;
     }
 
     public function setPdf(string $pdf): self


### PR DESCRIPTION
Found this to be a convenient feature. 😋