### PR TITLE
Drop Support for PHP 7.3 & Add Support for PHP 8.1

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4, 7.3]
+                php: [8.0, 7.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest]
-                php: [8.0, 7.4]
+                php: [8.1, 8.0, 7.4]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ composer.lock
 docs
 vendor
 tests/config.php
+.phpunit.result.cache
+.idea
+.vscode

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "php" : "^7.3|^8.0",
+        "php" : "^7.4|^8.0",
         "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/process": "^4.0|^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^8.0|^9.0"
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -14,7 +14,7 @@ class Pdf
 
     protected array $options = [];
 
-    public function __construct(string $binPath = null)
+    public function __construct(?string $binPath = null)
     {
         $this->binPath = $binPath ?? '/usr/bin/pdftotext';
     }
@@ -76,7 +76,7 @@ class Pdf
         return trim($process->getOutput(), " \t\n\r\0\x0B\x0C");
     }
 
-    public static function getText(string $pdf, string $binPath = null, array $options = []) : string
+    public static function getText(string $pdf, ?string $binPath = null, array $options = []) : string
     {
         return (new static($binPath))
             ->setOptions($options)

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -49,7 +49,7 @@ class Pdf
 
     protected function parseOptions(array $options): array
     {
-        $mapper = function (string $content) : array {
+        $mapper = function (string $content): array {
             $content = trim($content);
             if ('-' !== ($content[0] ?? '')) {
                 $content = '-'.$content;
@@ -58,14 +58,14 @@ class Pdf
             return explode(' ', $content, 2);
         };
 
-        $reducer = function (array $carry, array $option) : array {
+        $reducer = function (array $carry, array $option): array {
             return array_merge($carry, $option);
         };
 
         return array_reduce(array_map($mapper, $options), $reducer, []);
     }
 
-    public function text() : string
+    public function text(): string
     {
         $process = new Process(array_merge([$this->binPath], $this->options, [$this->pdf, '-']));
         $process->run();
@@ -76,7 +76,7 @@ class Pdf
         return trim($process->getOutput(), " \t\n\r\0\x0B\x0C");
     }
 
-    public static function getText(string $pdf, ?string $binPath = null, array $options = []) : string
+    public static function getText(string $pdf, ?string $binPath = null, array $options = []): string
     {
         return (new static($binPath))
             ->setOptions($options)

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -8,11 +8,11 @@ use Symfony\Component\Process\Process;
 
 class Pdf
 {
-    protected $pdf;
+    protected string $pdf;
 
-    protected $binPath;
+    protected string $binPath;
 
-    protected $options = [];
+    protected array $options = [];
 
     public function __construct(string $binPath = null)
     {


### PR DESCRIPTION
This PR;
- drops support for PHP 7.3 since [it reached its end of life and is no longer supported](https://www.php.net/eol.php),
- adds testing on PHP 8.1 environment.