### PR TITLE
Add detailed Linux distribution about Fedora-based

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ On a mac you can install the binary using brew
 brew install poppler
 ```
 
-If you're on RedHat or CentOS use this:
+If you're on RedHat, CentOS, Rocky Linux or Fedora use this:
 
 ```bash
 yum install poppler-utils


### PR DESCRIPTION
# Changed log

- As title, adding more detailed descriptions for Fedora-related distributions.
- The following command running logs that are verified for the `poppler-utils` package is available in above distributions.

Rocky Linux:

```sh
[root@rockylinux-s-1vcpu-1gb-amd-sgp1-01 ~]# yum search poppler-utils
Last metadata expiration check: 0:06:55 ago on Sat 11 Jun 2022 08:26:40 AM UTC.
=================================== Name Exactly Matched: poppler-utils ====================================
poppler-utils.x86_64 : Command line utilities for converting PDF files
[root@rockylinux-s-1vcpu-1gb-amd-sgp1-01 ~]# cat /etc/redhat-release
Rocky Linux release 8.6 (Green Obsidian)
```

Fedora:
```sh
[root@fedora-s-1vcpu-1gb-amd-sgp1-01 ~]# yum search poppler-utils
Last metadata expiration check: 0:00:29 ago on Sat 11 Jun 2022 08:34:10 AM UTC.
=================================== Name Exactly Matched: poppler-utils ====================================
poppler-utils.x86_64 : Command line utilities for converting PDF files
[root@fedora-s-1vcpu-1gb-amd-sgp1-01 ~]# cat /etc/redhat-release
Fedora release 34 (Thirty Four)
[root@fedora-s-1vcpu-1gb-amd-sgp1-01 ~]#
```