### PR TITLE
add timeout config for Symfony Process call

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -14,6 +14,8 @@ class Pdf
 
     protected array $options = [];
 
+    protected int $timeout = 60;
+
     public function __construct(?string $binPath = null)
     {
         $this->binPath = $binPath ?? '/usr/bin/pdftotext';
@@ -65,9 +67,15 @@ class Pdf
         return array_reduce(array_map($mapper, $options), $reducer, []);
     }
 
+    public function setTimeout($timeout) {
+        $this->timeout = $timeout;
+        return $this;
+    }
+
     public function text(): string
     {
         $process = new Process(array_merge([$this->binPath], $this->options, [$this->pdf, '-']));
+        $process->setTimeout($this->timeout);
         $process->run();
         if (!$process->isSuccessful()) {
             throw new CouldNotExtractText($process);
@@ -76,10 +84,11 @@ class Pdf
         return trim($process->getOutput(), " \t\n\r\0\x0B\x0C");
     }
 
-    public static function getText(string $pdf, ?string $binPath = null, array $options = []): string
+    public static function getText(string $pdf, ?string $binPath = null, array $options = [], $timeout = 60): string
     {
         return (new static($binPath))
             ->setOptions($options)
+            ->setTimeout($timeout)
             ->setPdf($pdf)
             ->text()
         ;

--- a/tests/PdfToTextTest.php
+++ b/tests/PdfToTextTest.php
@@ -6,6 +6,7 @@ use PHPUnit\Framework\TestCase;
 use Spatie\PdfToText\Exceptions\CouldNotExtractText;
 use Spatie\PdfToText\Exceptions\PdfNotFound;
 use Spatie\PdfToText\Pdf;
+use Symfony\Component\Process\Exception\InvalidArgumentException;
 
 class PdfToTextTest extends TestCase
 {
@@ -134,5 +135,16 @@ class PdfToTextTest extends TestCase
         $this->assertStringContainsString("This is page 2", $text);
         $this->assertStringNotContainsString("This is page 1", $text);
         $this->assertStringNotContainsString("This is page 3", $text);
+    }
+
+    /** @test */
+    public function it_will_throw_an_exception_when_timeout_is_a_negative_number()
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        $text = (new Pdf($this->pdftotextPath))
+            ->setPdf($this->dummyPdf)
+            ->setTimeout(-1)
+            ->text();
     }
 }


### PR DESCRIPTION
Fixes #17 

I needed the ability to increase the timeout when calling Symfony Process. Some of the PDFs I am converting to text are rather large and require more time than the default of 60 seconds.

A test was added to verify that the timeout is set on the Symfony Process by testing if Symfony throws an exception for a negative timeout value.

I'm happy to modify anything that Spatie's team would want to see reworked or improved.

Thanks!
