### PR TITLE
feat: check if bin file path exist or throw

### DIFF
--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -19,10 +19,24 @@ class Pdf
     public function __construct(?string $binPath = null)
     {
         $this->binPath = $binPath ?? '/usr/bin/pdftotext';
+        
+        if (!file_exists($binPath)) {
+            $binPath = '/usr/local/bin/pdftotext';
+        }
+        
+        if (!file_exists($binPath)) {
+            throw new \Exception(
+                sprintf('pdftotext not found. Please install it or set the path manually. See %s', 'https://github.com/spatie/pdf-to-text#requirements')
+            );
+        }
     }
 
     public function setPdf(string $pdf): self
     {
+        if (!file_exists($pdf)) {
+            throw new PdfNotFound("File `{$pdf}` not found");
+        }
+        
         if (!is_readable($pdf)) {
             throw new PdfNotFound("Could not read `{$pdf}`");
         }


### PR DESCRIPTION
# default path to `pdftotext`

Proposing to check for likely `$binPath` locations for `pdftotext`

Instead of using the output of `which pdftotext`

Closes https://github.com/spatie/pdf-to-text/discussions/35 https://github.com/spatie/pdf-to-text/discussions/62 https://github.com/spatie/pdf-to-text/discussions/58