### PR TITLE
Add support for Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4|^8.0",
-        "symfony/process": "^4.0|^5.0|^6.0"
+        "symfony/process": "^4.0|^5.0|^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",


### PR DESCRIPTION
`symfony/process` does not contain BC breaks, except the addition of native return types, which only impact classes extending the class of the component (which is not the case in that package), so the compatibility work is easy.