### PR TITLE
Add Default Binary Path Detection for pdftotext in Constructor

### DIFF
--- a/src/Exceptions/BinaryNotFoundException.php
+++ b/src/Exceptions/BinaryNotFoundException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Spatie\PdfToText\Exceptions;
+
+use Exception;
+
+class BinaryNotFoundException extends Exception
+{
+}

--- a/src/Pdf.php
+++ b/src/Pdf.php
@@ -3,6 +3,7 @@
 namespace Spatie\PdfToText;
 
 use Closure;
+use Spatie\PdfToText\Exceptions\BinaryNotFoundException;
 use Spatie\PdfToText\Exceptions\CouldNotExtractText;
 use Spatie\PdfToText\Exceptions\PdfNotFound;
 use Symfony\Component\Process\Process;
@@ -21,7 +22,26 @@ class Pdf
 
     public function __construct(?string $binPath = null)
     {
-        $this->binPath = $binPath ?? '/usr/bin/pdftotext';
+        $this->binPath = $binPath ?? $this->findPdfToText();
+    }
+
+    protected function findPdfToText(): string
+    {
+        $commonPaths = [
+            '/usr/bin/pdftotext',          // Common on Linux
+            '/usr/local/bin/pdftotext',    // Common on Linux
+            '/opt/homebrew/bin/pdftotext', // Homebrew on macOS (Apple Silicon)
+            '/opt/local/bin/pdftotext',    // MacPorts on macOS
+            '/usr/local/bin/pdftotext',    // Homebrew on macOS (Intel)
+        ];
+
+        foreach ($commonPaths as $path) {
+            if (is_executable($path)) {
+                return $path;
+            }
+        }
+
+        throw new BinaryNotFoundException("The required binary was not found or is not executable.");
     }
 
     public function setPdf(string $pdf): self


### PR DESCRIPTION
This enhances the constructor by adding a mechanism to automatically detect the default binary path for `pdftotext`. The method `findPdfToText()` checks several common paths on both Linux and macOS (including support for both Intel and Apple Silicon architectures). If a valid executable is found, it is set as the `binPath`; otherwise, a `BinaryNotFoundException` is thrown. This improvement increases the robustness of the class by handling different environments more gracefully and eliminates the need for hardcoded paths in the constructor.